### PR TITLE
feat: check analysis uses concurrency

### DIFF
--- a/RapidSplit/Screens/CheckAnalysisScreen.swift
+++ b/RapidSplit/Screens/CheckAnalysisScreen.swift
@@ -14,7 +14,6 @@ struct CheckAnalysisScreen: View {
     @Environment(Router.self) private var router
 
     let image: UIImage
-    private let context = CIContext()
 
     @State private var showSnackbar = false
     @State private var snackbarMessage: String = ""
@@ -65,51 +64,50 @@ struct CheckAnalysisScreen: View {
             Image(uiImage: image).resizable().aspectRatio(contentMode: .fit)
             Text(statusUpdates.joined(separator: "\n"))
         }
+        .onChange(of: phase, { oldValue, newValue in
+            self.statusUpdates.append(phase.displayTitle + "...")
+        })
         .task {
-            do {
-                guard let ciImage = CIImage(image: image) else {
-                    handleError(error: AnalysisError.failedImageConversion)
-                    return
-                }
-                phase = .detectingText
-                self.statusUpdates.append(phase.displayTitle + "...")
-                try await VisionService.shared
-                    .analyzeForText(image: ciImage,
-                                    progressHandler: handleProgess,
-                                    handleError: handleError
-                    ) { recognizedStrings in
-                        DispatchQueue.main.async {
-                            phase = .runningAIAnalysis
-                            self.statusUpdates.append(phase.displayTitle + "...")
-                            self.statusUpdates.append("Detected \(recognizedStrings.count) lines of text")
-                        }
-                        Task {
-                            await handleVisionFinished(recognizedStrings: recognizedStrings)
-                        }
-                    }
-            } catch let err {
-                print(err)
-                self.snackbarMessage = "Error: \(err.localizedDescription)"
-                self.showSnackbar = true
-            }
+            await runAnalysis()
         }
         .snackbar(isPresented: $showSnackbar, message: snackbarMessage)
     }
 
-    nonisolated private func handleError(error: Error) {
-        DispatchQueue.main.async {
-            print(error)
-            self.snackbarMessage = "Error: \(error.localizedDescription)"
-            self.showSnackbar = true
-        }
-    }
+    private func runAnalysis() async {
+        do {
+            // Check conversion
+            guard let ciImage = CIImage(image: image) else {
+                throw AnalysisError.failedImageConversion
+            }
 
-    nonisolated private func handleProgess(with request: VNRequest, progress: Double, error: Error?) {
-        if let error {
-            handleError(error: error)
-        }
-        DispatchQueue.main.async {
-            self.statusUpdates.append("\(Int(progress * 100))% complete processing text")
+            // Begin Image Recognition
+            self.phase = .detectingText
+            let recognizedStrings = try await VisionService.shared.analyzeForText(image: ciImage)
+
+            // Check recognition success
+            self.statusUpdates.append("Detected \(recognizedStrings.count) lines of text")
+            guard !recognizedStrings.isEmpty else {
+                throw AnalysisError.noRecognizedText
+            }
+
+            // Begin AI Analysis
+            self.phase = .runningAIAnalysis
+            let items = try await GenerationService.shared.generateCheckStructure(
+                recognizedStrings: recognizedStrings,
+                onPartial: handlePartialCheck
+            )
+            self.statusUpdates.append("Generated \(items.count) check items from scan")
+
+            // Make a name
+            self.phase = .namingCheck
+            let title = try await GenerationService.shared.generateCheckTitle(recognizedStrings: recognizedStrings)
+
+            // Finish
+            router.navigateTo(route: .overview(title: title, items: items))
+        } catch let err {
+            print(err)
+            self.snackbarMessage = "Error: \(err.localizedDescription)"
+            self.showSnackbar = true
         }
     }
 
@@ -119,30 +117,6 @@ struct CheckAnalysisScreen: View {
                 self.phase = .buildingCheckItems
                 self.statusUpdates.append(rawContent.jsonString)
             }
-        }
-    }
-
-    nonisolated private func handleVisionFinished(recognizedStrings: [String]) async {
-        guard !recognizedStrings.isEmpty else {
-            handleError(error: AnalysisError.noRecognizedText)
-            return
-        }
-
-        do {
-            let items = try await GenerationService.shared.generateCheckStructure(
-                recognizedStrings: recognizedStrings,
-                onPartial: handlePartialCheck
-            )
-            await MainActor.run {
-                self.phase = .namingCheck
-                self.statusUpdates.append(phase.displayTitle + "...")
-            }
-            let title = try await GenerationService.shared.generateCheckTitle(recognizedStrings: recognizedStrings)
-            await MainActor.run {
-                router.navigateTo(route: .overview(title: title, items: items))
-            }
-        } catch let err {
-            handleError(error: err)
         }
     }
 }

--- a/RapidSplit/Services/VisionService.swift
+++ b/RapidSplit/Services/VisionService.swift
@@ -13,42 +13,25 @@ import UIKit
 actor VisionService {
     static let shared = VisionService()
 
-    private init() { }
+    let recognitionRequest: RecognizeTextRequest
+
+    private init() {
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        self.recognitionRequest = request
+    }
 
     func analyzeForText(
         image: CIImage,
         orientation: CGImagePropertyOrientation? = nil,
-        progressHandler: VNRequestProgressHandler? = nil,
-        handleError: ((Error) -> Void)? = nil,
-        completion: sending @escaping ([String]) -> Void
-    ) throws {
-        let requestHandler = orientation == nil
-            ? VNImageRequestHandler(ciImage: image)
-            : VNImageRequestHandler(ciImage: image, orientation: orientation!)
+    ) async throws -> [String] {
+        let result = try await recognitionRequest.perform(on: image, orientation: orientation)
 
-        let request = VNRecognizeTextRequest { request, error in
-            if let error {
-                // You may want to surface this error to the UI.
-                handleError?(error)
-                return
-            }
-
-            guard let observations = request.results as? [VNRecognizedTextObservation] else { return }
-            let recognizedStrings = observations.compactMap { observation in
-                // TODO: we can do some more clever stuff here
-                // Return the string of the top VNRecognizedText instance.
-                return observation.topCandidates(1).first?.string
-            }
-
-            completion(recognizedStrings)
+        return result.map { observation in
+            // TODO: we can do some more clever stuff here
+            // Return the string of the top RecognizedTextObservation instance.
+            return observation.topCandidates(1).first?.string ?? ""
         }
-
-        request.recognitionLevel = .accurate
-        if let progressHandler {
-            request.progressHandler = progressHandler
-        }
-
-        try requestHandler.perform([request])
     }
 }
 

--- a/RapidSplit/Services/VisionService.swift
+++ b/RapidSplit/Services/VisionService.swift
@@ -13,19 +13,16 @@ import UIKit
 actor VisionService {
     static let shared = VisionService()
 
-    let recognitionRequest: RecognizeTextRequest
-
-    private init() {
-        var request = RecognizeTextRequest()
-        request.recognitionLevel = .accurate
-        self.recognitionRequest = request
-    }
+    private init() { }
 
     func analyzeForText(
         image: CIImage,
         orientation: CGImagePropertyOrientation? = nil,
     ) async throws -> [String] {
-        let result = try await recognitionRequest.perform(on: image, orientation: orientation)
+        var request = RecognizeTextRequest()
+        request.recognitionLevel = .accurate
+
+        let result = try await request.perform(on: image, orientation: orientation)
 
         return result.map { observation in
             // TODO: we can do some more clever stuff here

--- a/RapidSplitTests/VisionTests.swift
+++ b/RapidSplitTests/VisionTests.swift
@@ -35,24 +35,7 @@ struct VisionTests {
 
 
         // Act: Bridge the completion handler API to async/await
-        let recognized: [String] = try await withCheckedThrowingContinuation { continuation in
-            Task {
-                do {
-                    try await VisionService.shared.analyzeForText(
-                        image: ciImage,
-                        progressHandler: nil,
-                        handleError: { error in
-                            continuation.resume(throwing: error)
-                        },
-                        completion: { strings in
-                            continuation.resume(returning: strings)
-                        }
-                    )
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+        let recognized: [String] = try await VisionService.shared.analyzeForText(image: ciImage)
 
         // Assert: Recognized text should contain all expected lines
         #expect(recognized.count == lines.count, "Recognized lines mismatch \(recognized.count) != \(lines.count)")


### PR DESCRIPTION
I have refactored the check processing to use asynchronous concurrency so that it better leverages what i have built. Furthermore this fixes a bug where the analysis wasn't able to be cancelled.  